### PR TITLE
#165372954 Add hashtag filter button

### DIFF
--- a/src/actions/fetchtweets.actions.js
+++ b/src/actions/fetchtweets.actions.js
@@ -15,9 +15,9 @@ export const fetchTweetSuccess = (payload) => ({
     payload
 });
 
-export const fetchTweets = () => dispatch => {
+export const fetchTweets = (tag) => dispatch => {
     dispatch(fetchTweetRequest())
-    const url = "http://localhost:3000/tweets";
+    const url = `http://localhost:3000/tweet${tag ? '/'+tag : 's'}`;
     const token = localStorage.getItem('user')
     var headers = {
         'Authorization': `Bearer ${token}`,

--- a/src/actions/signup.actions.js
+++ b/src/actions/signup.actions.js
@@ -26,7 +26,7 @@ export const signup = (data, history) => dispatch => {
           )
         .then(response => {
             if (response.status === 201){
-                const { token } = response.data['auth_token']
+                const token = response.data['auth_token']
                 localStorage.setItem('user', token)
                 dispatch(signupSuccess(response.data))
                 history.push('/home')

--- a/src/assets/styles/App.css
+++ b/src/assets/styles/App.css
@@ -159,6 +159,11 @@ height: 100%;
 
 .tag-button{
   border-color: #000;
+  padding-right: 50px;
+}
+.tag-link{
+  color: #1A73E8;
+  cursor: pointer;
 }
 
 .avatar {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -21,6 +21,11 @@ export const FETCH_TWEET_ATTEMPT = 'FETCH_TWEET_ATTEMPT';
 export const FETCH_TWEET_FAILED = 'FETCH_TWEET_FAILED';
 export const FETCH_TWEET_SUCCESS = 'FETCH_TWEET_SUCCESS';
 
+// Fetch hash_tag constants
+export const FETCH_HASHTAG_ATTEMPT = 'FETCH_HASHTAG_ATTEMPT';
+export const FETCH_HASHTAG_FAILED = 'FETCH_HASHTAG_FAILED';
+export const FETCH_HASHTAG_SUCCESS = 'FETCH_HASHTAG_SUCCESS';
+
 export const initialState = {
     attempt: false,
     data: [],

--- a/src/reducers/fetchHashtagReducer.js
+++ b/src/reducers/fetchHashtagReducer.js
@@ -1,0 +1,33 @@
+import { FETCH_HASHTAG_ATTEMPT, FETCH_HASHTAG_FAILED, FETCH_HASHTAG_SUCCESS } from '../constants';
+
+const initialState = {
+    attempt: false,
+    data: [],
+    error: null
+}
+
+const fetchHashTagsReducer = (state = initialState, action) => {
+    switch(action.type) {
+        case FETCH_HASHTAG_ATTEMPT:
+            return {
+                ...state,
+                attempt: true
+            }
+        case FETCH_HASHTAG_SUCCESS:
+            return {
+                ...state,
+                attempt: false,
+                data: action.payload
+            }
+        case FETCH_HASHTAG_FAILED:
+            return {
+                ...state,
+                attempt: false,
+                error: action.error
+            }
+        default:
+            return state;
+    }
+}
+
+export default fetchHashTagsReducer;

--- a/src/reducers/rootReducer.js
+++ b/src/reducers/rootReducer.js
@@ -4,7 +4,8 @@ import loginReducer from './SigninReducer';
 import SignupReducer from './SignupReducer';
 import TweetReducer from './TweetReducer';
 import fetchTweetsReducer from './fetchTweetsReducer';
+import fetchHashtagReducer from './fetchHashtagReducer';
 
 export default combineReducers({
-  exampleReducer, loginReducer, SignupReducer, TweetReducer, fetchTweetsReducer
+  exampleReducer, loginReducer, SignupReducer, TweetReducer, fetchTweetsReducer,fetchHashtagReducer
 });


### PR DESCRIPTION
#### What does this PR do?
ensure a user is able to view current hashtag filter and clear the filter
#### Description of Task to be completed?
- Under “filtered by”, whichever hashtag you click on should then pop up as a button (which you can x) to show the user they are filtering the tweets by that hashtag
- If a user hits the x, the list should refresh to show the new filtering criteria (or all tweets) 
#### How should this be manually tested?
- checkout `ft-hashtag-filter-button-165372954` and run server
- login and go tweet section on the homepage
- click on any hashtag and you should see the button under `filtered by` update when you click on a hashtag
- When you click on the `x` on the button, the view will be updated with all the tweets
#### Any background context you want to provide?
 N/A
#### What are the relevant PT Stories?
[#165372954](https://www.pivotaltracker.com/story/show/165372954)
#### Screenshots (if appropriate)



#### Questions:
N/A